### PR TITLE
use individual files for redirects and concat at build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+
+# generated redirects file
+/static/_redirects

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+find redirects -type f -exec cat {} \; > static/_redirects
+
+gatsby build

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "build": "./build.sh",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",

--- a/redirects/bail
+++ b/redirects/bail
@@ -1,0 +1,1 @@
+/bail    https://bailfunds.github.io

--- a/redirects/form
+++ b/redirects/form
@@ -1,0 +1,1 @@
+/form https://airtable.com/shrZTndkJ2UGhmc9g

--- a/redirects/massbail
+++ b/redirects/massbail
@@ -1,0 +1,1 @@
+/massbail https://www.massbailfund.org/

--- a/redirects/repo
+++ b/redirects/repo
@@ -1,0 +1,1 @@
+/repo https://github.com/wipeyadocsoff/blm.to

--- a/redirects/scrub
+++ b/redirects/scrub
@@ -1,0 +1,1 @@
+/scrub   https://everestpipkin.github.io/image-scrubber/

--- a/redirects/table
+++ b/redirects/table
@@ -1,0 +1,1 @@
+/table https://airtable.com/shrD0qYRQR64XsXCc

--- a/scripts/pr-maker/pr-maker.js
+++ b/scripts/pr-maker/pr-maker.js
@@ -63,37 +63,21 @@ async function addPrToRecord(recordID, prLink) {
 
 async function makePr(slug, url) {
     // unique-ish branch name
-    const sanitizedBranch = slug.replace(/[^-a-z0-9_]/i, '-');
-    const branchName = `${sanitizedBranch}_${Date.now()}`;
+    const sanitizedSlug = slug.replace(/[^-a-z0-9_]/i, '-');
+    const branchName = `link_req_${sanitizedSlug}_${Date.now()}`;
 
-    const repo = github.repo('wipeyadocsoff/blm.to');
+    const repo = github.repo(`${PR_USERNAME}/blm.to`);
     const master = await repo.refAsync('heads/master');
 
     // create a branch
     await repo.createRefAsync(`refs/heads/${branchName}`, master[0].object.sha);
 
-    // get current file contents
-    redirects = await repo.contentsAsync('static/_redirects', branchName);
-
-    // append to contents
-    const text = Buffer.from(
-        redirects[0]['content'],
-        redirects[0]['encoding'],
-    ).toString('utf8');
-
-    // check if this already exists
-    const duplicate = !! text.match(RegExp(`^/${slug}\\s`, 'm'));
-
-    // commit
-    let title = `Link Request: ${slug} -> ${url}`;
-    if (duplicate) {
-        title = '[DUPLICATE] ' + title;
-    }
-    await repo.updateContentsAsync(
-        'static/_redirects',
+    // create a new file
+    const title = `Link Request: ${slug} -> ${url}`;
+    await repo.createContentsAsync(
+        `redirects/${sanitizedSlug}`,
         title,
-        `${text}\n/${slug} ${url}`,
-        redirects[0]['sha'],
+        `/${slug}    ${url}\n`,
         branchName,
     );
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,9 +1,0 @@
-/bail    https://bailfunds.github.io
-/scrub   https://everestpipkin.github.io/image-scrubber/
-
-/form https://airtable.com/shrZTndkJ2UGhmc9g
-/repo https://github.com/wipeyadocsoff/blm.to
-/table https://airtable.com/shrD0qYRQR64XsXCc
-
-
-/massbail https://www.massbailfund.org/


### PR DESCRIPTION
use files to make redirect requests so there's no merge conflicts (also helps detect duplication)